### PR TITLE
fixed issue where some object files won't get cleaned with "make clean"

### DIFF
--- a/linux_src/p7zip_4.65/CPP/7zip/Bundles/Alone/makefile
+++ b/linux_src/p7zip_4.65/CPP/7zip/Bundles/Alone/makefile
@@ -19,10 +19,10 @@ PROG=../../../../bin/t7z$(BINSUFFIX)
 LIBS=$(LOCAL_LIBS)
 
 T7Z_OBJS = \
-  ../../../../torrent7z/t7z.o \
-  ../../../../torrent7z/torrent7z_signature.o \
-  ../../../../torrent7z/w32t.o \
-  ../../../../torrent7z/usage.o
+  t7z.o \
+  torrent7z_signature.o \
+  w32t.o \
+  usage.o
 
 CONSOLE_OBJS = \
   ConsoleClose.o \

--- a/linux_src/p7zip_4.65/CPP/7zip/Bundles/Alone/makefile.list
+++ b/linux_src/p7zip_4.65/CPP/7zip/Bundles/Alone/makefile.list
@@ -201,7 +201,12 @@ SRCS=\
  ../../Crypto/Sha1.cpp \
  ../../Crypto/WzAes.cpp \
  ../../Crypto/ZipCrypto.cpp \
- ../../Crypto/ZipStrong.cpp
+ ../../Crypto/ZipStrong.cpp \
+ \
+ ../../../../torrent7z/t7z.cpp \
+ ../../../../torrent7z/torrent7z_signature.cpp \
+ ../../../../torrent7z/w32t.cpp \
+ ../../../../torrent7z/usage.cpp
 
 SRCS_C=\
  ../../../../C/Bra.c \

--- a/linux_src/p7zip_4.65/makefile.rules
+++ b/linux_src/p7zip_4.65/makefile.rules
@@ -558,3 +558,16 @@ HuffEnc.o : ../../../../C/HuffEnc.c
 7zCrcT8.o : ../../../../C/7zCrcT8.c
 	$(CC) $(CFLAGS) ../../../../C/7zCrcT8.c
 
+# t7z additional files
+t7z.o : ../../../../torrent7z/t7z.cpp
+	$(CXX) $(CXXFLAGS) ../../../../torrent7z/t7z.cpp
+
+torrent7z_signature.o : ../../../../torrent7z/torrent7z_signature.cpp
+	$(CXX) $(CXXFLAGS) ../../../../torrent7z/torrent7z_signature.cpp
+
+w32t.o : ../../../../torrent7z/w32t.cpp
+	$(CXX) $(CXXFLAGS) ../../../../torrent7z/w32t.cpp
+
+usage.o : ../../../../torrent7z/usage.cpp
+	$(CXX) $(CXXFLAGS) ../../../../torrent7z/usage.cpp
+


### PR DESCRIPTION
* t7z' *.o files are now also located in CPP/7zip/Bundles/Alone/
* this prevents incomplete cleanups when doing "make clean"