### PR TITLE
Fix -Wnarrowing on GCC 10

### DIFF
--- a/linux_src/p7zip_4.65/CPP/Windows/Error.cpp
+++ b/linux_src/p7zip_4.65/CPP/Windows/Error.cpp
@@ -13,7 +13,7 @@ bool MyFormatMessage(DWORD messageID, CSysString &message)
   const char * txt = 0;
   AString msg;
 
-  switch(messageID) {
+  switch((HRESULT)messageID) {
     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;


### PR DESCRIPTION
Build errors out on GCC 10 with ../../../Common/MyWindows.h:91:41: error: narrowing conversion of ‘-2147467263’ from ‘LONG’ {aka ‘int’} to ‘unsigned int’ [-Wnarrowing], etc, so cast the switch expression to HRESULT.  Ok, fair enough for a warning, but what I dont understand is why I'm getting an error rather than a warning cause I don't see -Werror anywhere here??? In any case I don't think casting the switch expression can cause any harm :P (but you never know with C++, there could be an overloaded operator(HRESULT) lurking somewhere ;)

g++ -O -s -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DNDEBUG -D_REENTRANT -DENV_UNIX -DCOMPRESS_MT -DCOMPRESS_BZIP2_MT -DCOMPRESS_MF_MT -DBREAK_HANDLER -DBENCH_MT -D_NO_CRYPTO -DWIN_LONG_PATH -DUNICODE -fPIE -D_UNICODE -DBUILD_SHARED_LIB=OFF -c -I../../../myWindows -I../../../ -I../../../include_windows ../../../Windows/Error.cpp