### PR TITLE
use system flags

### DIFF
--- a/linux_src/p7zip_4.65/makefile.glb
+++ b/linux_src/p7zip_4.65/makefile.glb
@@ -1,12 +1,12 @@
 
 RM=rm -f
-CFLAGS=-c \
+CFLAGS+=-c \
 -I../../../../C \
 -I../../../myWindows \
 -I../../../include_windows \
 -I../../..
 
-CXXFLAGS=-c \
+CXXFLAGS+=-c \
 -I../../../myWindows \
 -I../../../ \
 -I../../../include_windows


### PR DESCRIPTION
Prevents overriding system flags from environment like `CXXFLAGS="..." make`.